### PR TITLE
无rememberMe时过期时间的修复

### DIFF
--- a/src/main/java/github/javaguide/springsecurityjwtguide/security/constants/SecurityConstants.java
+++ b/src/main/java/github/javaguide/springsecurityjwtguide/security/constants/SecurityConstants.java
@@ -17,7 +17,7 @@ public class SecurityConstants {
     /**
      * rememberMe 为 false 的时候过期时间是1个小时
      */
-    public static final long EXPIRATION = 6L;
+    public static final long EXPIRATION = 60L * 60L;
     /**
      * rememberMe 为 true 的时候过期时间是7天
      */


### PR DESCRIPTION
在设置rememberMe为false的时候,注释上面写的是过期时间为1小时
但是其实只有6秒,所以修改为 60 * 60 即为1小时