### PR TITLE
feat:增加 H2 内存数据库支持，增加Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,21 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>2.6.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/github/javaguide/springsecurityjwtguide/security/config/SecurityConfig.java
+++ b/src/main/java/github/javaguide/springsecurityjwtguide/security/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // 授权异常处理
                 .exceptionHandling().authenticationEntryPoint(new JWTAuthenticationEntryPoint())
                 .accessDeniedHandler(new JWTAccessDeniedHandler());
-
+        // 防止H2 web 页面的Frame 被拦截
+        http.headers().frameOptions().disable();
     }
 
 }

--- a/src/main/java/github/javaguide/springsecurityjwtguide/security/config/SwaggerConfig.java
+++ b/src/main/java/github/javaguide/springsecurityjwtguide/security/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package github.javaguide.springsecurityjwtguide.security.config;
+
+import github.javaguide.springsecurityjwtguide.security.constants.SecurityConstants;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.ParameterBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.ModelRef;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Parameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    @Bean
+    public Docket createRestApi() {
+        ParameterBuilder ticketPar = new ParameterBuilder();
+        List<Parameter> pars = new ArrayList<>();
+        ticketPar.name(SecurityConstants.TOKEN_HEADER).description("user token")
+                .modelRef(new ModelRef("string")).parameterType("header")
+                .required(false).build(); //header中的ticket参数非必填，传空也可以
+        pars.add(ticketPar.build());    //根据每个方法名也知道当前方法在设置什么参数
+
+
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("github.javaguide.springsecurityjwtguide"))
+                .paths(PathSelectors.any())
+                .build()
+                .globalOperationParameters(pars);
+    }
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Spring Security JWT Guide")
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,13 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/jwt-demo?useSSL=false&serverTimezone=CTT
-spring.datasource.username=root
-spring.datasource.password=123456
+spring.datasource.url=jdbc:h2:mem:jwt-demo
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.driverClassName =org.h2.Driver
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 server.port=9333
+
+spring.datasource.platform=h2
+spring.h2.console.settings.web-allow-others=true
+spring.h2.console.enabled=true


### PR DESCRIPTION
1. 增加H2内存数据库支持，无须MySQL，一键启动
项目启动后访问 http://{host}:9333/h2-console/
2. 增加Swagger，方便调用接口

TODO:

- [ ] login接口单独写在Controller中（Swagger目前不能识别login接口）